### PR TITLE
add_metrics

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,6 +24,8 @@ clean-targets:         # directories to be removed by `dbt clean`
     - "target"
     - "dbt_modules"
 
+vars:
+  dbt_metrics_calendar_model: all_days
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/models/marts/aggregates/monthly_revenue.sql
+++ b/models/marts/aggregates/monthly_revenue.sql
@@ -1,0 +1,6 @@
+select * 
+from {{ metrics.metric(
+    metric_name='revenue',
+    grain='month',
+    dimensions=['priority_code']
+) }}

--- a/models/marts/core/core.yml
+++ b/models/marts/core/core.yml
@@ -37,3 +37,19 @@ models:
         tests:
           - unique
           - not_null
+
+
+metrics:
+  - name: revenue
+    label: Revenue
+    model: ref('fct_orders')
+    description: "Total revenue from orders in the specified time period"
+
+    type: sum
+    sql: net_item_sales_amount
+
+    timestamp: order_date
+    time_grains: [day, week, month, quarter, year]
+
+    dimensions: 
+      - priority_code

--- a/models/utils/all_days.sql
+++ b/models/utils/all_days.sql
@@ -1,7 +1,15 @@
-
+with base_spine as (
 {{ dbt_utils.date_spine(
     datepart="day",
-    start_date="to_date('01/01/1992', 'mm/dd/yyyy')",
+    start_date="to_date('01/01/1990', 'mm/dd/yyyy')",
     end_date="dateadd(year, 1, current_date)"
    )
 }} 
+)
+
+select date_day
+     , date_trunc('WEEK',date_day) as date_week
+     , date_trunc('MONTH',date_day) as date_month
+     , date_trunc('QUARTER',date_day) as date_quarter
+     , date_trunc('YEAR',date_day) as date_year
+  from base_spine

--- a/packages.yml
+++ b/packages.yml
@@ -1,7 +1,9 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.0
+    version: 0.8.5
   - package: dbt-labs/codegen
     version: 0.5.0
   - package: dbt-labs/dbt_external_tables
     version: 0.8.0
+  - package: dbt-labs/metrics
+    version: 0.2.0


### PR DESCRIPTION
All changes here are associated with adding metrics to the partner demo project:

- The metrics package was added to packages.yml
- A metric was added to `core.yml` for the `fct_orders` model to calculate total sales amount by order date. Unfortunately there aren't any great dimensions to include, but one was included for demo purposes.
- The custom calendar and variable in `dbt_project.yml` are to allow metrics to work with this dataset. The date spine that the metrics package uses only goes back to 2010 and the data in our project goes back to 1992. To be able to use metrics with this, it required creating a new date spine and setting the dbt_metrics_calendar_model variable equal to a reference to the custom date spine model.