### PR TITLE
Add grants config in dbt-project.yml

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,6 +35,8 @@ models:
   redshift_dbt_demo:
       # Applies to all files under models/example/
       +bind: false
+      +grants:
+        select: ['group transformer']
       staging:
           materialized: table
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,8 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'redshift_dbt_demo'
-version: '1.0.0'
+version: '1.2.0'
+require-dbt-version: '>=1.2.0'
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.


### PR DESCRIPTION
This PR applies the newly available [grants](https://docs.getdbt.com/reference/resource-configs/grants) config to this project.

For this PR to be merged we require our dbt cloud environments (dev & prod) to make use of dbt 1.2.0

I have tested running the entire repo with `dbt build` on my local machine and it works:
```sh
14:34:11  Finished running 6 view models, 15 table models, 1 incremental model, 34 tests in 0 hours 0 minutes and 42.20 seconds (42.20s).
14:34:11  
14:34:11  Completed successfully
14:34:11  
14:34:11  Done. PASS=56 WARN=0 ERROR=0 SKIP=0 TOTAL=56
```
I have then run with the added new configuration (which seems not perfectly [documented](https://docs.getdbt.com/reference/resource-configs/grants)? I guessed the way to grant permission to a group).
And: 

```sh
14:53:24  Finished running 6 view models, 15 table models, 1 incremental model, 34 tests in 0 hours 0 minutes and 48.04 seconds (48.04s).
14:53:24  
14:53:24  Completed successfully
14:53:24  
14:53:24  Done. PASS=56 WARN=0 ERROR=0 SKIP=0 TOTAL=56
```
We loose 6 sec in performance.