### PR TITLE
Fix: Grant Select by allowing usage

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -26,6 +26,9 @@ clean-targets:         # directories to be removed by `dbt clean`
     - "dbt_modules"
 
 
+on-run-end:
+  - "{{ grant_usage_on_schemas(schemas, 'group transformer') }}"
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 

--- a/macros/grant_all_on_schema.sql
+++ b/macros/grant_all_on_schema.sql
@@ -1,9 +1,0 @@
-{% macro grant_all_on_schemas(schemas, role) %}
-  {% for schema in schemas %}
-    grant usage on schema {{ schema }} to role {{ role }};
-    grant select on all tables in schema {{ schema }} to role {{ role }};
-    grant select on all views in schema {{ schema }} to role {{ role }};
-    grant select on future tables in schema {{ schema }} to role {{ role }};
-    grant select on future views in schema {{ schema }} to role {{ role }};
-  {% endfor %}
-{% endmacro %}

--- a/macros/grant_usage_on_schemas.sql
+++ b/macros/grant_usage_on_schemas.sql
@@ -1,6 +1,6 @@
-{% macro grant_usage_on_schemas(schemas, role) %}
+{% macro grant_usage_on_schemas(schemas, grantee) %}
   {% for schema in schemas %}
-    grant usage on schema {{ schema }} to {{ role }};
-    {{ log("Granting Usage to " ~ role ~ " on " ~ schema) }}
+    grant usage on schema {{ schema }} to {{ grantee }};
+    {{ log("Granting Usage to " ~ grantee ~ " on " ~ schema) }}
   {% endfor %}
 {% endmacro %}

--- a/macros/grant_usage_on_schemas.sql
+++ b/macros/grant_usage_on_schemas.sql
@@ -1,0 +1,6 @@
+{% macro grant_usage_on_schemas(schemas, role) %}
+  {% for schema in schemas %}
+    grant usage on schema {{ schema }} to {{ role }};
+    {{ log("Granting Usage to " ~ role ~ " on " ~ schema) }}
+  {% endfor %}
+{% endmacro %}


### PR DESCRIPTION
`grants` is a tricky feature because it's performed on a table object level only. I totally forgot about the `usage` grant that needs to given for any other grant to be validated. [From the AWS Docs](https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html#:~:text=Grants%20USAGE%20privilege%20on%20a%20specific%20schema%2C%20which%20makes%20objects%20in%20that%20schema%20accessible%20to%20users.%20Specific%20actions%20on%20these%20objects%20must%20be%20granted%20separately%20(for%20example%2C%20SELECT%20or%20UPDATE%20privileges%20on%20tables).)

> *Grants USAGE privilege on a specific schema, which makes objects in that schema accessible to users. Specific actions on these objects must be granted separately (for example, SELECT or UPDATE privileges on tables). By default, all users have CREATE and USAGE privileges on the PUBLIC schema.*
> 

Our feature does not handle this for you, but you need to know about it. one approach here as taken by @AlexFrid  for our snowflake platform which I replicated in this PR which will improve the changes from #5