### PR TITLE
Update to 1.3.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,8 +3,8 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'redshift_dbt_demo'
-version: '1.2.0'
-require-dbt-version: '>=1.2.0'
+version: '1.3.0'
+require-dbt-version: '>=1.3.0'
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.


### PR DESCRIPTION
We want to work on top of our latest releases. Therefore, this PR addresses the update to  dbt version to 1.3.0.

More info here:
https://github.com/dbt-labs/dbt-core/releases

